### PR TITLE
MCSC-CheckModeFix 

### DIFF
--- a/app/pages/ClaimingHigherOrAdditionalTaxRateReliefPage.scala
+++ b/app/pages/ClaimingHigherOrAdditionalTaxRateReliefPage.scala
@@ -37,11 +37,7 @@ case object ClaimingHigherOrAdditionalTaxRateReliefPage extends QuestionPageWith
     }
 
   override def navigateInCheckModeAA(answers: UserAnswers, submission: Submission): Call =
-    answers.get(ClaimingHigherOrAdditionalTaxRateReliefPage) match {
-      case Some(true)  => controllers.routes.HowMuchTaxReliefController.onPageLoad(CheckMode)
-      case Some(false) => controllers.routes.CheckYourAnswersController.onPageLoad
-      case _           => controllers.routes.JourneyRecoveryController.onPageLoad(None)
-    }
+    navigateInNormalModeAA(answers, submission)
 
   override def navigateInNormalModeLTAOnly(answers: UserAnswers, submission: Submission): Call =
     answers.get(ClaimingHigherOrAdditionalTaxRateReliefPage) match {
@@ -51,11 +47,7 @@ case object ClaimingHigherOrAdditionalTaxRateReliefPage extends QuestionPageWith
     }
 
   override def navigateInCheckModeLTAOnly(answers: UserAnswers, submission: Submission): Call =
-    answers.get(ClaimingHigherOrAdditionalTaxRateReliefPage) match {
-      case Some(true)  => controllers.routes.HowMuchTaxReliefController.onPageLoad(NormalMode)
-      case Some(false) => controllers.routes.CheckYourAnswersController.onPageLoad
-      case _           => controllers.routes.JourneyRecoveryController.onPageLoad(None)
-    }
+    navigateInNormalModeLTAOnly(answers, submission)
 
   private def isMemberCredit(submission: Submission, mode: Mode): Call = {
     val memberCredit: Int = submission.calculation.map(_.inDates.map(_.memberCredit).sum).getOrElse(0)

--- a/app/pages/HowMuchTaxReliefPage.scala
+++ b/app/pages/HowMuchTaxReliefPage.scala
@@ -35,26 +35,22 @@ case object HowMuchTaxReliefPage extends QuestionPageWithLTAOnlyNavigation[BigIn
     }
 
   override def navigateInCheckModeAA(answers: UserAnswers, submission: Submission): Call =
+    navigateInNormalModeAA(answers, submission)
+
+  override def navigateInNormalModeLTAOnly(answers: UserAnswers, submission: Submission): Call =
     answers.get(HowMuchTaxReliefPage) match {
-      case Some(_) => controllers.routes.CheckYourAnswersController.onPageLoad
+      case Some(_) =>
+        val numberOfSchemes: Int = SchemeService.allSchemeDetailsForTaxReliefLength(submission.calculationInputs)
+        numberOfSchemes match {
+          case 0 => controllers.routes.JourneyRecoveryController.onPageLoad(None)
+          case 1 => controllers.routes.DeclarationsController.onPageLoad
+          case _ => controllers.routes.WhichPensionSchemeWillPayTaxReliefController.onPageLoad(NormalMode)
+        }
       case _       => controllers.routes.JourneyRecoveryController.onPageLoad(None)
     }
-
-  override def navigateInNormalModeLTAOnly(answers: UserAnswers, submission: Submission): Call = {
-    val numberOfSchemes: Int = SchemeService.allSchemeDetailsForTaxReliefLength(submission.calculationInputs)
-
-    numberOfSchemes match {
-      case 0 => controllers.routes.JourneyRecoveryController.onPageLoad(None)
-      case 1 => controllers.routes.DeclarationsController.onPageLoad
-      case _ => controllers.routes.WhichPensionSchemeWillPayTaxReliefController.onPageLoad(NormalMode)
-    }
-  }
 
   override def navigateInCheckModeLTAOnly(answers: UserAnswers, submission: Submission): Call =
-    answers.get(HowMuchTaxReliefPage) match {
-      case Some(_) => controllers.routes.CheckYourAnswersController.onPageLoad
-      case _       => controllers.routes.JourneyRecoveryController.onPageLoad(None)
-    }
+    navigateInNormalModeLTAOnly(answers, submission)
 
   private def isSchemePageValid(answers: UserAnswers, submission: Submission, mode: Mode): Call = {
     val numberOfSchemes: Int = SchemeService.allSchemeDetailsForTaxReliefLength(submission.calculationInputs)

--- a/app/pages/WhichPensionSchemeWillPayTaxReliefPage.scala
+++ b/app/pages/WhichPensionSchemeWillPayTaxReliefPage.scala
@@ -36,16 +36,13 @@ case object WhichPensionSchemeWillPayTaxReliefPage extends QuestionPageWithLTAOn
   }
 
   override def navigateInCheckModeAA(answers: UserAnswers, submission: Submission): Call =
-    answers.get(WhichPensionSchemeWillPayTaxReliefPage) match {
-      case Some(_) => controllers.routes.CheckYourAnswersController.onPageLoad
-      case _       => controllers.routes.JourneyRecoveryController.onPageLoad(None)
-    }
+    navigateInNormalModeAA(answers, submission)
 
   override def navigateInNormalModeLTAOnly(answers: UserAnswers, submission: Submission): Call =
     controllers.routes.DeclarationsController.onPageLoad
 
   override def navigateInCheckModeLTAOnly(answers: UserAnswers, submission: Submission): Call =
-    controllers.routes.DeclarationsController.onPageLoad
+    navigateInNormalModeLTAOnly(answers, submission)
 
   private def isMemberCredit(submission: Submission, mode: Mode): Call = {
     val memberCredit = submission.calculation.map(_.inDates.map(_.memberCredit).sum).getOrElse(0)

--- a/test/pages/ClaimingHigherOrAdditionalTaxRateReliefPageSpec.scala
+++ b/test/pages/ClaimingHigherOrAdditionalTaxRateReliefPageSpec.scala
@@ -145,7 +145,7 @@ class ClaimingHigherOrAdditionalTaxRateReliefPageSpec extends PageBehaviours {
         checkNavigation(result, "/submission-service/how-much-tax-relief-claiming-for")
       }
 
-      "to check your answers when answered no and LTA only" in {
+      "to Declarations answered no and LTA only" in {
         val ua = emptyUserAnswers
           .set(
             ClaimingHigherOrAdditionalTaxRateReliefPage,
@@ -156,7 +156,7 @@ class ClaimingHigherOrAdditionalTaxRateReliefPageSpec extends PageBehaviours {
 
         val result = ClaimingHigherOrAdditionalTaxRateReliefPage.navigate(CheckMode, ua, ltaOnlySubmission).url
 
-        checkNavigation(result, "/check-your-answers")
+        checkNavigation(result, "/declarations")
       }
 
       "to journey recovery when not answered and LTA only" in {
@@ -178,10 +178,10 @@ class ClaimingHigherOrAdditionalTaxRateReliefPageSpec extends PageBehaviours {
 
         val result = ClaimingHigherOrAdditionalTaxRateReliefPage.navigate(CheckMode, ua, submissionNotInCredit).url
 
-        checkNavigation(result, "/submission-service/change-how-much-tax-relief-claiming-for")
+        checkNavigation(result, "/submission-service/how-much-tax-relief-claiming-for")
       }
 
-      "to CYA when answered no and member is not in credit" in {
+      "to Declarations when answered no and member is not in credit" in {
         val ua = emptyUserAnswers
           .set(
             ClaimingHigherOrAdditionalTaxRateReliefPage,
@@ -192,7 +192,7 @@ class ClaimingHigherOrAdditionalTaxRateReliefPageSpec extends PageBehaviours {
 
         val result = ClaimingHigherOrAdditionalTaxRateReliefPage.navigate(CheckMode, ua, submissionNotInCredit).url
 
-        checkNavigation(result, "/check-your-answers")
+        checkNavigation(result, "/declarations")
       }
 
       "to JourneyRecovery when not selected" in {

--- a/test/pages/HowMuchTaxReliefPageSpec.scala
+++ b/test/pages/HowMuchTaxReliefPageSpec.scala
@@ -82,7 +82,7 @@ class HowMuchTaxReliefPageSpec extends PageBehaviours {
 
     "must navigate correctly in CheckMode when LTAOnly" - {
 
-      "to CheckYourAnswers" in {
+      "to WhichPensionSchemeWillPay" in {
         val ua = emptyUserAnswers
           .set(
             HowMuchTaxReliefPage,
@@ -93,7 +93,7 @@ class HowMuchTaxReliefPageSpec extends PageBehaviours {
 
         val result = HowMuchTaxReliefPage.navigate(CheckMode, ua, ltaOnlySubmissionWithMultipleSchemes).url
 
-        checkNavigation(result, "/check-your-answers")
+        checkNavigation(result, "/submission-service/which-pension-scheme-will-pay-tax-relief")
       }
     }
 
@@ -163,7 +163,7 @@ class HowMuchTaxReliefPageSpec extends PageBehaviours {
 
     "must navigate correctly in CheckMode" - {
 
-      "to CYA" in {
+      "to WhichPensionSchemeWillPay" in {
         val ua = emptyUserAnswers
           .set(
             HowMuchTaxReliefPage,
@@ -174,7 +174,7 @@ class HowMuchTaxReliefPageSpec extends PageBehaviours {
 
         val result = HowMuchTaxReliefPage.navigate(CheckMode, ua, submissionWithMultipleSchemes).url
 
-        checkNavigation(result, "/check-your-answers")
+        checkNavigation(result, "/submission-service/which-pension-scheme-will-pay-tax-relief")
       }
 
       "to JourneyRecovery when not selected" in {

--- a/test/pages/WhichPensionSchemeWillPayTaxReliefPageSpec.scala
+++ b/test/pages/WhichPensionSchemeWillPayTaxReliefPageSpec.scala
@@ -147,7 +147,7 @@ class WhichPensionSchemeWillPayTaxReliefSpec extends PageBehaviours {
 
     "must navigate correctly in CheckMode" - {
 
-      "to CYA" in {
+      "to Declarations" in {
         val ua = emptyUserAnswers
           .set(
             WhichPensionSchemeWillPayTaxReliefPage,
@@ -166,7 +166,7 @@ class WhichPensionSchemeWillPayTaxReliefSpec extends PageBehaviours {
           Submission("sessionId", "submissionUniqueId", mockCalculationInputsWithAA, Some(calculationResponse))
         val result                 = WhichPensionSchemeWillPayTaxReliefPage.navigate(CheckMode, ua, submission).url
 
-        checkNavigation(result, "/check-your-answers")
+        checkNavigation(result, "/declarations")
       }
 
       "to JourneyRecovery when not answered" in {


### PR DESCRIPTION
ClaimingHigherOrAdditionalTaxRateReliefPage + HowMuchTaxReliefPage + WhichPensionSchemeWillPayTaxReliefPage modified to delegate to use NormalMode navigation when accessed from CYA to ensure all dependent values are captured until more specific check mode navigation is implemented.